### PR TITLE
swap ampersand for htmlcode

### DIFF
--- a/remark/ansi.html
+++ b/remark/ansi.html
@@ -159,7 +159,7 @@ To achieve this, add the following to the end of the remark presentation:
       });
       // extract the embedded styling from ansi spans
       $('code.terminal span.hljs-ansi').replaceWith(function(i, x) {
-        return x.replace(/&lt;(\/?(\w+).*?)&gt;/g, '<$1>')
+        return x.replace(/&#38;lt;(\/?(\w+).*?)&#38;gt;/g, '<$1>')
       });
     </script>
     ...


### PR DESCRIPTION
Hi,

In your example, slide 3 shows what code to copy-paste to make this work.

After trying to make this work for a while, I looked at the source of the presentation, and what's rendered in the browser is different to what's in the footer of the presentation.

I looked further up, and inside your code block you've got the same code as in the footer - but the htmlcode required in the `<script>` block is actually being rendered in the browser (not sure if that's remark doing it when it shouldn't - perhaps a bug?).

Anyway - swapping out the ampersand with the equivalent htmlcode, since they're rendered here, causes the correct result in the browser, so no-one else ends up confused by copy/pasting from that example.
