### PR TITLE
Three things but mainly option for no JQuery

### DIFF
--- a/remark/ansi.html
+++ b/remark/ansi.html
@@ -219,7 +219,9 @@ same directory as your remark presentation.
 
 ---
 
-# Worked Example to Capture Coloured Command Output (e.g. `git`)
+# Worked Example
+
+This example captures coloured command output from `git`
 
 1. Build and install [aha](https://github.com/theZiz/aha):
 .small[
@@ -240,6 +242,18 @@ To capture directly to clipboard, use:
   - `pbcopy` for OS X
   - `xsel --clipboard` for Linux
   - `getclip` for Cygwin
+
+.small[
+*Tip:* for git commands which don't support `--color`, e.g. `status` set `color.*` 
+in [git config](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_colors_in_git).
+
+Using the `-c` [option](https://git-scm.com/docs/git#git--cltnamegtltvaluegt) you can do this without affecting 
+your global or local config. For example:
+```terminal
+# use color.status for git status, color.ui for anything else
+josh@brick ~/repos/aha $ git -c color.status=always status | aha -b -n | pbcopy
+```
+]
 
 ---
 

--- a/remark/ansi.html
+++ b/remark/ansi.html
@@ -136,13 +136,31 @@ to be interpreted by the highlight.js engine used in remark.
 ---
 name: code
 
-# The Code
+# How it Works
 
 The results produced by `aha` are translated via the highlight.js engine (using
-the [language definition](terminal.language.js)) and a small jQuery script to
+the [language definition](terminal.language.js)) and a small script to
 substitute the embedded style elements after the page has rendered.
 
-To achieve this, add the following to the end of the remark presentation:
+### Customization
+The terminal language definition assumes a prompt of the form:
+
+```terminal
+user@host /path/x $ 
+```
+
+If you would like a different prompt style, get your regex on and alter it in
+the [language definition](terminal.language.js).
+
+---
+
+# How to Set it Up With JQuery
+
+*This is the JQuery option, the next slide shows installation without JQuery*
+
+1. Download the [language definition](terminal.language.js) and save it in the
+same directory as your remark presentation.
+1. Add the following to the end of the remark presentation:
 
 .small[
 ```html
@@ -168,16 +186,36 @@ To achieve this, add the following to the end of the remark presentation:
 
 ---
 
-# Customization
+# How to Set it Up Without JQuery
 
-The terminal language definition assumes a prompt of the form:
+*This is the vanilla JS option, the previous slide shows installation with JQuery*
 
-```terminal
-user@host /path/x $ 
+1. Download the [language definition](terminal.language.js) and save it in the
+same directory as your remark presentation.
+1. Add the following to the end of the remark presentation:
+
+.small[
+```html
+    ...
+    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js"></script>
+    <script type="text/javascript">
+      var hljs = remark.highlighter.engine;
+    </script>
+    <script src="terminal.language.js" type="text/javascript"></script>
+    <script type="text/javascript">
+      var slideshow = remark.create({
+        highlightStyle: 'monokai'
+      });
+      // extract the embedded styling from ansi spans
+      var highlighted = document.querySelectorAll("code.terminal span.hljs-ansi");
+      Array.prototype.forEach.call(highlighted, function(next) {
+        next.insertAdjacentHTML("beforebegin", next.textContent);
+        next.parentNode.removeChild(next);
+      });
+    </script>
+    ...
 ```
-
-If you would like a different prompt style, get your regex on and alter it in
-the [language definition](terminal.language.js).
+]
 
 ---
 

--- a/remark/ansi.html
+++ b/remark/ansi.html
@@ -154,41 +154,7 @@ the [language definition](terminal.language.js).
 
 ---
 
-# How to Set it Up With JQuery
-
-*This is the JQuery option, the next slide shows installation without JQuery*
-
-1. Download the [language definition](terminal.language.js) and save it in the
-same directory as your remark presentation.
-1. Add the following to the end of the remark presentation:
-
-.small[
-```html
-    ...
-    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js"></script>
-    <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
-    <script type="text/javascript">
-      var hljs = remark.highlighter.engine;
-    </script>
-    <script src="terminal.language.js" type="text/javascript"></script>
-    <script type="text/javascript">
-      var slideshow = remark.create({
-        highlightStyle: 'monokai'
-      });
-      // extract the embedded styling from ansi spans
-      $('code.terminal span.hljs-ansi').replaceWith(function(i, x) {
-        return x.replace(/&#38;lt;(\/?(\w+).*?)&#38;gt;/g, '<$1>')
-      });
-    </script>
-    ...
-```
-]
-
----
-
-# How to Set it Up Without JQuery
-
-*This is the vanilla JS option, the previous slide shows installation with JQuery*
+# How to Set it Up
 
 1. Download the [language definition](terminal.language.js) and save it in the
 same directory as your remark presentation.
@@ -358,8 +324,10 @@ This application is subject to the <span style="color:#3333FF;font-weight:bold;"
         highlightStyle: 'monokai'
       });
       // extract the embedded styling from ansi spans
-      $('code.terminal span.hljs-ansi').replaceWith(function(i, x) {
-        return x.replace(/&lt;(\/?(\w+).*?)&gt;/g, '<$1>')
+      var highlighted = document.querySelectorAll("code.terminal span.hljs-ansi");
+      Array.prototype.forEach.call(highlighted, function(next) {
+        next.insertAdjacentHTML("beforebegin", next.textContent);
+        next.parentNode.removeChild(next);
       });
     </script>
 

--- a/remark/ansi.html
+++ b/remark/ansi.html
@@ -128,7 +128,7 @@ lrwxr-xr-x   1 root wheel       11 Sep 24  2009 <span style="color:aqua;font-wei
 ```
 ]
 
-# Solution
+### Solution
 
 Use the `aha` Ansi HTML Adaptor to capture output and paste the result as code
 to be interpreted by the highlight.js engine used in remark.
@@ -165,6 +165,10 @@ To achieve this, add the following to the end of the remark presentation:
     ...
 ```
 ]
+
+---
+
+# Customization
 
 The terminal language definition assumes a prompt of the form:
 


### PR DESCRIPTION
Thanks for the how-to it was most useful.

This PR has three goals:
1. Explicitly mention that one must download the language definition file.
1. Tweak the slides a little so that content does not flow out of viewport (I had to read the source code to see the full content of some slides).
1. Provide a vanilla js version to remove the need for JQuery.

The last one was the most important to me and I'm thinking other people will want that too.
